### PR TITLE
fix(admin-ui): fix sweetalert2 and move ng2-toasty dependency

### DIFF
--- a/apps/admin/package.json
+++ b/apps/admin/package.json
@@ -87,7 +87,6 @@
     "lodash": "4.17.4",
     "ng-formly": "github:formly-js/ng-formly",
     "ng2-file-upload": "1.2.1",
-    "ng2-toasty": "4.0.0",
     "ngrx-store-freeze": "0.1.9",
     "ngrx-store-logger": "0.1.8",
     "protractor": "5.1.2",

--- a/apps/admin/src/styles.scss
+++ b/apps/admin/src/styles.scss
@@ -24,7 +24,7 @@ $navbar-brand-logo: url('./assets/logo.png');
 $navbar-brand-logo-size: 130px auto;
 
 @import '~coreui-styles/scss/style.scss';
-@import '~ng2-toasty/style-bootstrap.css';
+@import '~@colmena/admin-ui/src/styles.css';
 @import '~simple-line-icons/css/simple-line-icons.css';
 @import '~font-awesome/css/font-awesome.css';
 @import './assets/animate.css';

--- a/packages/admin-ui/package-lock.json
+++ b/packages/admin-ui/package-lock.json
@@ -1,4 +1,6 @@
 {
+  "name": "@colmena/admin-ui",
+  "version": "0.0.0",
   "lockfileVersion": 1,
   "dependencies": {
     "moment": {
@@ -25,6 +27,11 @@
       "version": "1.7.0",
       "resolved": "https://registry.npmjs.org/ngx-bootstrap/-/ngx-bootstrap-1.7.0.tgz",
       "integrity": "sha512-meIW/QWofwgPtfGXg+DQPAq/Yvs0233bVvzP2eSmwuXfLzoGAp9XBivVcSK65yZMwpFbr9DXZUxonsbx2hukag=="
+    },
+    "sweetalert2": {
+      "version": "6.6.5",
+      "resolved": "https://registry.npmjs.org/sweetalert2/-/sweetalert2-6.6.5.tgz",
+      "integrity": "sha1-///BBkcR/3hwvIrv4WePlezCkNs="
     },
     "tslib": {
       "version": "1.7.1",

--- a/packages/admin-ui/package.json
+++ b/packages/admin-ui/package.json
@@ -6,6 +6,7 @@
     "ng-formly": "^1.0.0-rc.7",
     "ng2-file-upload": "^1.2.1",
     "ng2-toasty": "4.0.0",
-    "ngx-bootstrap": "^1.6.6"
+    "ngx-bootstrap": "^1.6.6",
+    "sweetalert2": "^6.6.5"
   }
 }

--- a/packages/admin-ui/src/services/ui.service.ts
+++ b/packages/admin-ui/src/services/ui.service.ts
@@ -1,10 +1,9 @@
 import { Injectable } from '@angular/core'
 import { assign, noop } from 'lodash'
-// import swal, { SweetAlertOptions } from 'sweetalert2'
+import swal, { SweetAlertOptions } from 'sweetalert2'
 
 import { ToastyService, ToastyConfig } from 'ng2-toasty'
 
-const swal = (args) => Promise.resolve(args)
 @Injectable()
 export class UiService {
 

--- a/packages/admin-ui/src/styles.css
+++ b/packages/admin-ui/src/styles.css
@@ -1,0 +1,2 @@
+@import '~ng2-toasty/style-bootstrap.css';
+@import '~sweetalert2/dist/sweetalert2.css';


### PR DESCRIPTION
### Description

This should fix the alerts and moves the ng2-toasty dependency to the package where it's actually used. 

#### Related issues

<!--
Please use the following link syntaxes:

- #42 (to reference issues in the current repository)
- colmena/colmena#42 (to reference issues in another repository)
-->

- None

### Checklist

<!--
Please mark your choice with an "x" (i.e. [x], see
-->

- [ ] New tests added or existing tests modified to cover all changes

<!--
Thanks to strongloop/loopback for this template
-->
