### PR TITLE
cli: add clean script to remove top-level node_modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,12 +44,12 @@ Software installed on your system:
 
 Globally installed Node packages:
 
-- Angular CLI (`npm install -g @angular/cli`)
-- LernaJS (`npm install -g lerna`)
+- [Angular CLI](https://github.com/angular/angular-cli)
+- [Lerna](https://github.com/lerna/lerna)
+- [LoopBack CLI](https://github.com/strongloop/loopback-cli)
 
-And lastly (not needed to run the app, but will be useful during development):
 
-- LoopBack CLI (`npm install -g loopback-cli`)
+    $ npm install -g @angular/cli lerna loopback-cli
 
 #### Clone repo
 
@@ -107,7 +107,6 @@ You should now be able to connect to the Admin on http://192.168.12.34:9000 and 
 Colmena is still a work in progress and not all functionality is built yet.
 
 - Almost no ACLS are implemented, this means that the API can be used by whoever has access to it
-- There is no advanced user management
 - The interface does not reflect the user role (admin/manager/user)
 - Content will be leaking across domains, while this should not be possible
 

--- a/bin/clean.js
+++ b/bin/clean.js
@@ -1,0 +1,15 @@
+#!/usr/bin/env node
+const { clean, pJoin } = require('./lib/functions')
+
+const pJson = require('../package.json')
+const packageName = '@colmena/colmena'
+const projectPath = pJoin(__dirname, '..')
+
+if (!pJson || !pJson.name || pJson.name !== packageName) {
+  return console.log(`Could not find the ${packageName} project`)
+}
+console.log(`[clean] Removing node_modules from project path ${projectPath}`)
+
+clean(projectPath)
+
+console.log('[clean] Done.')

--- a/bin/lib/functions.js
+++ b/bin/lib/functions.js
@@ -1,0 +1,74 @@
+
+const fs = require('fs')
+const path = require('path')
+
+const pJoin = (p, f) => path.join(p, f)
+
+
+/**
+ * Synchronously check if path exists
+ * @param p the path to check
+ */
+const exists = p => fs.existsSync(p)
+
+/**
+ * Synchronously get a list of directories in a dir
+ * @param p the dir to read
+ * @returns array A list of dir names
+ */
+const getDirectories = p => readDir(p)
+  .filter(f => isDir(pJoin(p, f)))
+
+/**
+ * Synchronously check if path is a dir
+ * @param p the path to check
+ */
+const isDir = p => fs.lstatSync(p).isDirectory()
+
+/**
+ * Synchronously read the contents of a path
+ * @param p the path to read
+ * @returns array A list of file/dir names
+ */
+const readDir = p => fs.readdirSync(p)
+
+/**
+ * Synchronously remove a dir
+ * @param p the dir to remove
+ */
+const rmDir = p => fs.rmdirSync(p)
+
+/**
+ * Synchronously remove a file
+ * @param f the file to remove
+ */
+const rmFile = f => fs.unlinkSync(f)
+
+/**
+ * Synchronously remove a dir recursively
+ * @param p the dir to remove
+ */
+const rmDirRecursive = p => {
+  if(!exists(p)) return
+  readDir(p)
+    .map(dirs => pJoin(p, dirs))
+    .map(item => isDir(item) ? rmDirRecursive(item) : rmFile(item))
+  rmDir(p)
+}
+
+/**
+ * Clean the node_modules dir from a path
+ * @param p the dir to remove
+ */
+const clean = p => getDirectories(p)
+  .filter(dir => dir === 'node_modules')
+  .map(dir => pJoin(p, dir))
+  .map(dir => {
+    console.log(`[!] Removing ${dir}`)
+    rmDirRecursive(dir)
+  })
+
+module.exports = {
+  pJoin,
+  clean,
+}

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "admin"
   ],
   "scripts": {
-    "clean": "lerna clean --yes",
+    "clean": "lerna clean --yes && node bin/clean",
     "clean:api": "cd apps/api && npm run clean",
     "clean:admin": "cd apps/admin && npm run clean",
     "contributors:add": "all-contributors add",


### PR DESCRIPTION
### Description

This script is used to remove the top-level node_modules from the project. We cannot rely on `rimraf` to be installed on the top-level directory and we should try to rely on as little global installed packages as possible. 
